### PR TITLE
Add origin properties to cloud events

### DIFF
--- a/v4/createCloudevent.js
+++ b/v4/createCloudevent.js
@@ -3,6 +3,9 @@ const createCloudevent = ({
 	datacontenttype,
 	dlx = 'dlx',
 	id,
+	originid,
+	originsource,
+	origintype,
 	source,
 	specversion = '1.0',
 	type,
@@ -23,6 +26,11 @@ const createCloudevent = ({
 		// Optional data
 		data,
 		datacontenttype,
+
+		// Origin data
+		originid = originid || id,
+		originsource = originsource || source,
+		origintype = origintype || type,
 	}
 	return cloudevent
 }


### PR DESCRIPTION
# Overview
This will allow for cloudevent (1) propagation throughout an application and/or (2) return to the origin for enriched cloudevents following a traditional command-request model. 